### PR TITLE
Fix bugs to ignore Capital letter at the beginning of the Sentence

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "textlint-scripts": "^2.1.0"
   },
   "dependencies": {
-    "array-includes": "^3.0.1",
+    "array-includes": "^3.0.3",
     "is-capitalized": "^1.0.0"
   }
 }

--- a/src/textlint-rule-unexpanded-acronym.js
+++ b/src/textlint-rule-unexpanded-acronym.js
@@ -68,35 +68,21 @@ module.exports = function (context, options = {}) {
                     && acronymCreator.canExtractAcronym()) {
                     // Create Acronym
                     var acronyms = acronymCreator.extractAcronym();
-                    //if the acronyms is a string i.e. only one acronym
-                    if(!Array.isArray(acronyms)){
-                        if (isWordSatisfy(acronyms)) {
-                            expandedAcronymList.push(acronyms);
-                        }
-                    //if the acronyms is an array of acronym, we need to extract the satisfied ones
-                    }else{
-                        acronyms.forEach(acronym => {
-                            if (isWordSatisfy(acronym)) {
-                                expandedAcronymList.push(acronym);
-                            }
-                        });
-                    }
-                }
-            });
-            if (acronymCreator.canExtractAcronym()) {
-                // Create Acronym
-                var acronyms = acronymCreator.extractAcronym();
-                if(!Array.isArray(acronyms)){
-                    if (isWordSatisfy(acronyms)) {
-                        expandedAcronymList.push(acronyms);
-                    }
-                }else{
                     acronyms.forEach(acronym => {
                         if (isWordSatisfy(acronym)) {
                             expandedAcronymList.push(acronym);
                         }
                     });
                 }
+            });
+            if (acronymCreator.canExtractAcronym()) {
+                // Create Acronym
+                var acronyms = acronymCreator.extractAcronym();
+                acronyms.forEach(acronym => {
+                    if (isWordSatisfy(acronym)) {
+                        expandedAcronymList.push(acronym);
+                    }
+                });
             }
         },
         [Syntax.Document + ":exit"](node){

--- a/src/textlint-rule-unexpanded-acronym.js
+++ b/src/textlint-rule-unexpanded-acronym.js
@@ -68,12 +68,14 @@ module.exports = function (context, options = {}) {
                     && acronymCreator.canExtractAcronym()) {
                     // Create Acronym
                     var acronyms = acronymCreator.extractAcronym();
+                    //if the acronyms is a string i.e. only one acronym
                     if(!Array.isArray(acronyms)){
                         if (isWordSatisfy(acronyms)) {
                             expandedAcronymList.push(acronyms);
                         }
+                    //if the acronyms is an array of acronym, we need to extract the satisfied ones
                     }else{
-                        Array.from(acronyms).forEach(acronym => {
+                        acronyms.forEach(acronym => {
                             if (isWordSatisfy(acronym)) {
                                 expandedAcronymList.push(acronym);
                             }
@@ -84,12 +86,17 @@ module.exports = function (context, options = {}) {
             if (acronymCreator.canExtractAcronym()) {
                 // Create Acronym
                 var acronyms = acronymCreator.extractAcronym();
-                
-                Array.from(acronyms).forEach(acronym => {
-                    if (isWordSatisfy(acronym)) {
-                        expandedAcronymList.push(acronym);
+                if(!Array.isArray(acronyms)){
+                    if (isWordSatisfy(acronyms)) {
+                        expandedAcronymList.push(acronyms);
                     }
-                });
+                }else{
+                    acronyms.forEach(acronym => {
+                        if (isWordSatisfy(acronym)) {
+                            expandedAcronymList.push(acronym);
+                        }
+                    });
+                }
             }
         },
         [Syntax.Document + ":exit"](node){

--- a/src/textlint-rule-unexpanded-acronym.js
+++ b/src/textlint-rule-unexpanded-acronym.js
@@ -27,7 +27,7 @@ Step
 3. expandedAcronymList.includes(acronymList)
     - Not found Acronym and throw error
  */
-export default function (context, options = {}) {
+module.exports = function (context, options = {}) {
     const minAcronymLength = options.min_acronym_len || defaultOptions.min_acronym_len;
     const maxAcronymLength = options.max_acronym_len || defaultOptions.max_acronym_len;
     const ignoreAcronymList = options.ignore_acronyms || defaultOptions.ignore_acronyms;
@@ -67,18 +67,29 @@ export default function (context, options = {}) {
                 } else if (!includes(acronymJoiningWords, word) // ignore of and...
                     && acronymCreator.canExtractAcronym()) {
                     // Create Acronym
-                    var acronym = acronymCreator.extractAcronym();
-                    if (isWordSatisfy(acronym)) {
-                        expandedAcronymList.push(acronym);
+                    var acronyms = acronymCreator.extractAcronym();
+                    if(!Array.isArray(acronyms)){
+                        if (isWordSatisfy(acronyms)) {
+                            expandedAcronymList.push(acronyms);
+                        }
+                    }else{
+                        Array.from(acronyms).forEach(acronym => {
+                            if (isWordSatisfy(acronym)) {
+                                expandedAcronymList.push(acronym);
+                            }
+                        });
                     }
                 }
             });
             if (acronymCreator.canExtractAcronym()) {
                 // Create Acronym
-                var acronym = acronymCreator.extractAcronym();
-                if (isWordSatisfy(acronym)) {
-                    expandedAcronymList.push(acronym);
-                }
+                var acronyms = acronymCreator.extractAcronym();
+                
+                Array.from(acronyms).forEach(acronym => {
+                    if (isWordSatisfy(acronym)) {
+                        expandedAcronymList.push(acronym);
+                    }
+                });
             }
         },
         [Syntax.Document + ":exit"](node){

--- a/src/word-utils.js
+++ b/src/word-utils.js
@@ -25,13 +25,13 @@ export function expandOneWordToAcronym(CapitalWord) {
 }
 /*
  * create Acronym from words.
- * @param words (array)
+ * @param {string[]} words
  * @returns (1)string if only one word (2) array if multiple words 
  */
 export function expandWordsToAcronym(words) {
     //XMLHttpRequest -> XHR
     if (words.length === 1) {
-        return expandOneWordToAcronym(words[0]);
+        return [expandOneWordToAcronym(words[0])];
     }
     else{
         const result = [];
@@ -44,8 +44,8 @@ export function expandWordsToAcronym(words) {
 
         //In American Broadcast Company -> ["I", "IA", "IAB", "IABC"]
         words.reverse().reduce((acronym, word, i) => {
-            acronym += word.charAt(0);
-            result.push(acronym)
+            acronym.push(word.charAt(0));
+            result.push(acronym.join(""))
             return acronym;
         }, []);
         return result;

--- a/src/word-utils.js
+++ b/src/word-utils.js
@@ -31,12 +31,24 @@ export function expandOneWordToAcronym(CapitalWord) {
  * @example World Health Organization -> WHO
  */
 export function expandWordsToAcronym(words) {
-    if (words.length === 1) {
+    if (words.length == 1) {
         return expandOneWordToAcronym(words[0]);
     }
+    else{
     // World Health Organization -> WHO
-    return words.reduce((acronym, word) => {
-        acronym += word.charAt(0);
-        return acronym;
-    }, "");
+        let result = [];
+
+        let output = words.reverse().reduce((acronym, word, i) => {
+            acronym.unshift(word.charAt(0))
+            result.push(acronym.join(""))
+            return acronym;
+        }, []);
+
+        let output_1 = words.reverse().reduce((acronyms, word, i) => {
+            acronyms += word.charAt(0);
+            result.push(acronyms)
+            return acronyms;
+        }, []);
+        return result;
+    }
 }

--- a/src/word-utils.js
+++ b/src/word-utils.js
@@ -25,29 +25,28 @@ export function expandOneWordToAcronym(CapitalWord) {
 }
 /*
  * create Acronym from words.
- * @param words
- * @returns {string}
- * @example XMLHttpRequest -> XHR
- * @example World Health Organization -> WHO
+ * @param words (array)
+ * @returns (1)string if only one word (2) array if multiple words 
  */
 export function expandWordsToAcronym(words) {
-    if (words.length == 1) {
+    //XMLHttpRequest -> XHR
+    if (words.length === 1) {
         return expandOneWordToAcronym(words[0]);
     }
     else{
-    // World Health Organization -> WHO
-        let result = [];
-
-        let output = words.reverse().reduce((acronym, word, i) => {
+        const result = [];
+        //In American Broadcast Company -> ["C", "BC", "ABC", "IABC"]
+        words.reverse().reduce((acronym, word, i) => {
             acronym.unshift(word.charAt(0))
             result.push(acronym.join(""))
             return acronym;
         }, []);
 
-        let output_1 = words.reverse().reduce((acronyms, word, i) => {
-            acronyms += word.charAt(0);
-            result.push(acronyms)
-            return acronyms;
+        //In American Broadcast Company -> ["I", "IA", "IAB", "IABC"]
+        words.reverse().reduce((acronym, word, i) => {
+            acronym += word.charAt(0);
+            result.push(acronym)
+            return acronym;
         }, []);
         return result;
     }

--- a/test/textlint-rule-unexpanded-acronym-test.js
+++ b/test/textlint-rule-unexpanded-acronym-test.js
@@ -24,6 +24,7 @@ IEEE: (I triple E) Institute of Electrical and Electronics Engineers
 NAACP: (N double A C P) National Association for the Advancement of Colored People
 NCAA: (N C double A or N C two A or N C A A) National Collegiate Athletic Association
 In the Amazon Web Service, it can be short as AWS.
+Enter the Amazon Resource Names(ARN) for the Lambda you created in the setting
 `
         },
         // options

--- a/test/textlint-rule-unexpanded-acronym-test.js
+++ b/test/textlint-rule-unexpanded-acronym-test.js
@@ -13,7 +13,7 @@ always remember (or at least consider).this foodstuff's effect on one's ever-exp
 Now we know what SOC stands for`,
         // capitalized word
         "ABC can stand form the Australian Broadcasting Commission",
-        "XHR is XMLHttpRequest",
+        "XHR is known as XMLHttpRequest.",
         {
             text: `
 VHSIC stands for "Very High Speed Integrated Circuit".
@@ -23,6 +23,7 @@ SQL: ([siːkwəl] or ess-cue-el) Structured Query Language.
 IEEE: (I triple E) Institute of Electrical and Electronics Engineers
 NAACP: (N double A C P) National Association for the Advancement of Colored People
 NCAA: (N C double A or N C two A or N C A A) National Collegiate Athletic Association
+In the Amazon Web Service, it can be short as AWS.
 `
         },
         // options


### PR DESCRIPTION
Hi, @azu 
As I was using this rule on my documents, I found a bug that if there is a capital letter at the beginning of the sentence and there is an explanation to an acronym right after it, the rule won't extract the right acronym for the comparison. Here is an example:
```
In the Amazon Web Service, it can be short as AWS.
```
In this case, previously the rule will extract `IAWS` to compare with `AWS` because "the" is an `acronymJoiningWords`, which generates an error message. 

In order to fix it, I first reverse the `AcronymCreater` array and loop using reduce and add the first character to beginning on every iteration and finally join on every iteration and push to result array
```
{"S", "WS", "AWS", "IAWS"}
```
Then check this array using `isWordSatidfy` method and push the good ones to `expandedAcronymList` to compare with `AWS`.

I added this test case in the `textlint-rule-unexpanded-acronym-test.js` and it passed all the previous test as well.

I also update the `array-includes` package to the latest version.

Cheers!